### PR TITLE
Fix PVLive line styles

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -223,7 +223,7 @@ def plot_pvlive(fig, gsp_id, pvlive_data, pvlive_gsp_sum_dayafter, pvlive_gsp_su
         y = [i.solar_generation_kw / 1000 for i in v]
 
         line = {"color": get_colour_from_model_name(k)}
-        if k == "PVLive Updated Estimate":
+        if k == "PVLive Initial Estimate":
             line["dash"] = "dash"
 
         fig.add_trace(go.Scatter(x=x, y=y, mode="lines", name=k, line=line))


### PR DESCRIPTION
A previous commit (my bad) broke switched the line styles so that the initial estimate was shown with a solid line and the updated estimate was a dashed line. This reverses the change to what it should be.