### PR TITLE
Hide Intraday Forecasts Initially in Plotly Figure

### DIFF
--- a/src/plots/elexon_plots.py
+++ b/src/plots/elexon_plots.py
@@ -62,6 +62,12 @@ def add_elexon_plot(
             full_time_df = pd.DataFrame(full_time_range, columns=["start_time"])
             forecast = full_time_df.merge(forecast, on="start_time", how="left")
 
+            # Set visibility based on process type
+            if process_types[i] in ["Intraday Process", "Intraday Total"]:
+                visibility = 'legendonly'
+            else:
+                visibility = True
+
             fig.add_trace(
                 go.Scatter(
                     x=forecast["start_time"],
@@ -70,6 +76,7 @@ def add_elexon_plot(
                     name=f"Elexon {process_types[i]}",
                     line=dict(color="#318CE7", dash=line_style),
                     connectgaps=False,
+                    visible=visibility
                 )
             )
 
@@ -143,7 +150,7 @@ def determine_start_and_end_datetimes(
     if end_datetimes and end_datetimes[-1]:
         end_datetime_utc = end_datetimes[-1]
     else:
-        end_datetime_utc = start_datetime_utc + timedelta(days=7)
+        end_datetime_utc = start_datetime_utc + timedelta(days=3)
 
     # Ensure end_datetime_utc is a datetime object
     if isinstance(end_datetime_utc, date) and not isinstance(end_datetime_utc, datetime):


### PR DESCRIPTION
## Description

This pull request updates the `add_elexon_plot` function to set the initial visibility of specific forecast traces in the Plotly figure. The "Intraday Process" and "Intraday Total" forecasts will now be hidden by default when the page first loads, but will still be included in the legend.

PFA the screenshot : 

![image](https://github.com/user-attachments/assets/09c8421b-13b1-4e0f-8a0e-04bef8389b32)

Fixes #180 

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
