### PR TITLE
Add conditional display of elexon plot for national region in forecast page

### DIFF
--- a/src/forecast.py
+++ b/src/forecast.py
@@ -195,11 +195,11 @@ def forecast_page():
             )
         )
 
-        # Call the function to add Elexon plot and capture the returned figure
-        fig = add_elexon_plot(fig, start_datetimes, end_datetimes)
+        # Only add Elexon plot if the National region is selected
+        if gsp_id == 0:
+            fig = add_elexon_plot(fig, start_datetimes, end_datetimes)
 
     st.plotly_chart(fig, theme="streamlit")
-
 
 def plot_pvlive(fig, gsp_id, pvlive_data, pvlive_gsp_sum_dayafter, pvlive_gsp_sum_inday):
     # pvlive on the chart


### PR DESCRIPTION
## Description

This PR modifies the `forecast_page()` function to conditionally display the Elexon plot only when the "National" region is selected. 

Fixes #183

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
