### PR TITLE
site wise penalty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .env
+myenv
+src/venv.
+shsohos
+*.pyc
 src/.streamlit/secrets.toml

--- a/src/pvsite_forecast.py
+++ b/src/pvsite_forecast.py
@@ -17,13 +17,6 @@ import plotly.graph_objects as go
 import pytz
 
 # Penalty Calculator
-# Give uuids for region + asset type + parse in the capcity from the site
-# Penalty Calculator
-def calculate_penalty(df, region, asset_type, capacity_kw):
-    """
-    Calculate penalties dynamically based on region, asset type, and capacity.
-    """
-    # Define penalty bands for combinations of region and asset type
 def calculate_penalty(df, region, asset_type, capacity_kw):
     """
     Calculate penalties dynamically based on region, asset type, and capacity.
@@ -31,16 +24,16 @@ def calculate_penalty(df, region, asset_type, capacity_kw):
     # Define penalty bands for combinations of region and asset type
     penalty_bands = {
         ("Rajasthan", "solar"): [
-            (10, 15, 0.1),
-            (15, None, 1.0),
+            (10, 15, 0.1),  # Band (lowest bound of the band range, highest bound of the band range, penalty that particular band carries)
+            (15, None, 1.0), # Band (lowest bound of the band range, no highest bound of the band range, penalty that particular band carries)
         ],
         ("Madhya Pradesh", "wind"): [
-            (10, 20, 0.25),
+            (10, 20, 0.25), 
             (20, 30, 0.5),
             (30, None, 0.75),
         ],
         ("Gujarat", "solar"): [
-            (7, 15, 0.25),
+            (7, 15, 0.25), 
             (15, 23, 0.5),
             (23, None, 0.75),
         ],
@@ -96,7 +89,7 @@ def pvsite_forecast_page():
         unsafe_allow_html=True,
     )
     # get site_uuids from database
-    url = 'postgresql://main:vPV%xXs6AiviZ8WP@127.0.0.1:5433/indiadbdevelopment'
+    url = os.environ["SITES_DB_URL"]
     connection = DatabaseConnection(url=url, echo=True)
     with connection.get_session() as session:
         sites = get_all_sites(session=session)

--- a/src/pvsite_forecast.py
+++ b/src/pvsite_forecast.py
@@ -172,7 +172,7 @@ def pvsite_forecast_page():
 
         # get site from database, if india set day_ahead_timezone_delta_hours to 5.5 hours
         with connection.get_session() as session:
-            site = site_uuids(session, site_selection_uuid)
+            site = get_site_by_uuid(session, site_selection_uuid)
             if site.country == "india":
                 day_ahead_timezone_delta_hours = 5.5
 

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -3,13 +3,12 @@ import pandas as pd
 import numpy as np
 import pytest
 
-
 def test_calculate_penalty():
     """
-    Test the calculate_penalty function with mock data, regions, asset types, and dynamic capacities.
+    Test the calculate_penalty function with mock data and fixed capacity.
     """
 
-    # Mock input DataFrame
+    # Create a mock DataFrame
     df = pd.DataFrame(
         {
             "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
@@ -18,42 +17,22 @@ def test_calculate_penalty():
         }
     )
 
-    # Mock region, asset type, and capacity
+    # Test inputs
     region = "Karnataka"
     asset_type = "solar"
-    capacity_kw = 2  # Capacity specific to the mock site
+    capacity_kw = 2  # Small capacity for testing
 
-    # Penalty bands configuration
-    penalty_bands = {
-        ("Karnataka", "solar"): [
-            (10, 20, 0.1),  # Band 1
-            (20, 30, 0.5),  # Band 2
-            (30, None, 0.75),  # Open-ended Band
-        ]
-    }
-
-    # Check if penalty bands exist for the provided region and asset type
-    if (region, asset_type) not in penalty_bands:
-        pytest.fail(f"No penalty bands found for region '{region}' and asset type '{asset_type}'")
-
-    # Call the calculate_penalty function
-    penalty_df, total_penalty = calculate_penalty(df, region, asset_type, capacity_kw)
-
-    # Define expected results
-    expected_total_penalty = 0.42  # Update based on correct manual calculations
+    # Expected results
+    expected_total_penalty = 0.42  # Adjust based on manual calculation
     expected_penalty_df = pd.Series([0.01, 0.02, 0.05, 0.05, 0.29], index=df.index)
+
+    # Run penalty calculation
+    penalty_df, total_penalty = calculate_penalty(df, str(region), str(asset_type), capacity_kw)
+
+    # Debugging outputs
+    print("Calculated total penalty:", total_penalty)
+    print("Calculated penalties by block:", penalty_df)
 
     # Assertions
     np.testing.assert_almost_equal(total_penalty, expected_total_penalty, decimal=2)
-    pd.testing.assert_series_equal(
-        penalty_df,
-        expected_penalty_df,
-        check_dtype=False,
-        check_exact=False,
-    )
-
-    # Print outputs for debugging
-    print("Penalty DataFrame:\n", penalty_df)
-    print("Total Penalty:", total_penalty)
-
-
+    pd.testing.assert_series_equal(penalty_df, expected_penalty_df, check_dtype=False)

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -5,43 +5,31 @@ import pytest
 
 
 def test_calculate_penalty():
-    """
-    Test the calculate_penalty function with mock data using the correct calculation approach.
-    """
-    df = pd.DataFrame({
-        "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
-        "forecast_power_kw": [0.1, 0.2, 0.3, 0.4, 0.5],  # forecast
-        "generation_power_kw": [0.2, 0.3, 0.5, 0.5, 1.0],  # actual
-        "capacity_kw": [2.0, 2.0, 2.0, 2.0, 2.0]  # AVC
-    })
+    df = pd.DataFrame(
+        {
+            "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
+            "forecast_power_kw": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "generation_power_kw": [0.2, 0.3, 0.5, 0.5, 1],
+        }
+    )
 
     region = "Karnataka"
     asset_type = "solar"
-    capacity_kw = 2.0
-
-    # Let's calculate expected results manually for one row to verify:
-    # For first row:
-    # deviation = 100 * (0.2 - 0.1) / 2 = 5% (below 15% threshold, no penalty)
-    # For third row:
-    # deviation = 100 * (0.5 - 0.3) / 2 = 10% (below 15% threshold, no penalty)
-    # For fifth row:
-    # deviation = 100 * (1.0 - 0.5) / 2 = 25% (in 25-35% band)
+    capacity_kw = 2
 
     penalty_bands = {
         ("Karnataka", "solar"): [
-            (15, 25, 0.1),  # Band 1: 15-25%
-            (25, 35, 0.2),  # Band 2: 25-35%
-            (35, None, 0.3),  # Band 3: >35%
+            (10, 20, 0.25),
+            (20, 30, 0.5),
+            (30, None, 0.75),
         ]
     }
 
     penalty_df, total_penalty = calculate_penalty(df, str(region), str(asset_type), capacity_kw)
     
-    # With these deviations, most values fall below the 15% threshold except the last one
     expected_penalty_df = pd.Series([0.0, 0.0, 0.0, 0.0, 0.3], index=df.index)
     expected_total_penalty = 0.3
 
-    # Assertions
     np.testing.assert_almost_equal(total_penalty, expected_total_penalty, decimal=2)
     pd.testing.assert_series_equal(
         penalty_df,

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -13,15 +13,15 @@ def test_calculate_penalty():
     df = pd.DataFrame(
         {
             "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
-            "forecast_power_kw": [1, 2, 3, 4, 5],
-            "generation_power_kw": [2, 3, 4, 5, 10],
+            "forecast_power_kw": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "generation_power_kw": [0.2, 0.3, 0.5, 0.5, 1],
         }
     )
 
     # Mock region, asset type, and capacity
     region = "Karnataka"
     asset_type = "solar"
-    capacity_kw = 200  # Capacity specific to the mock site
+    capacity_kw = 2  # Capacity specific to the mock site
 
     # Penalty bands configuration
     penalty_bands = {
@@ -55,4 +55,5 @@ def test_calculate_penalty():
     # Print outputs for debugging
     print("Penalty DataFrame:\n", penalty_df)
     print("Total Penalty:", total_penalty)
+
 

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -1,11 +1,15 @@
 from pvsite_forecast import calculate_penalty
 import pandas as pd
 import numpy as np
+import pytest
 
 
 def test_calculate_penalty():
+    """
+    Test the calculate_penalty function with mock data and fixed capacity.
+    """
 
-    # set up dataframe
+    # Create a mock DataFrame
     df = pd.DataFrame(
         {
             "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
@@ -14,10 +18,28 @@ def test_calculate_penalty():
         }
     )
 
-    # calculate penalty
-    penalty_df, total_penalty = calculate_penalty(df, capacity_kw=2)
-    print(penalty_df)
+    # Assume capacity and mock region + asset type mapping
+    capacity_kw = 2
+    region = "Karnataka"
+    asset_type = "solar"
 
-    # check results
-    # TODO check result
-    assert np.round(total_penalty,2) == 0.42
+    # Set penalty bands for the region and asset type
+    penalty_bands = {
+        ("Karnataka", "solar"): [
+            (10, 20, 0.1),  # Band 1
+            (20, 30, 0.5),  # Band 2
+            (30, None, 0.75),  # Open-ended Band
+        ]
+    }
+
+    # Calculate penalty
+    penalty_df, total_penalty = calculate_penalty(df, region, asset_type, capacity_kw, penalty_bands)
+
+    # Expected results for validation
+    expected_total_penalty = 0.42  # Adjust based on correct calculations
+    expected_penalty_df = pd.Series([0.01, 0.02, 0.05, 0.05, 0.29], index=df.index)
+
+    # Assertions
+    np.testing.assert_almost_equal(total_penalty, expected_total_penalty, decimal=2)
+    pd.testing.assert_series_equal(penalty_df, expected_penalty_df, check_dtype=False)
+

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -3,12 +3,12 @@ import pandas as pd
 import numpy as np
 import pytest
 
+
 def test_calculate_penalty():
     """
-    Test the calculate_penalty function with mock data and fixed capacity.
+    Test the calculate_penalty function with mock data, regions, asset types, and dynamic capacities.
     """
-
-    # Create a mock DataFrame
+    # Mock input DataFrame
     df = pd.DataFrame(
         {
             "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
@@ -17,22 +17,33 @@ def test_calculate_penalty():
         }
     )
 
-    # Test inputs
+    # Mock region, asset type, and capacity
     region = "Karnataka"
     asset_type = "solar"
-    capacity_kw = 2  # Small capacity for testing
+    capacity_kw = 2
 
-    # Expected results
-    expected_total_penalty = 0.42  # Adjust based on manual calculation
-    expected_penalty_df = pd.Series([0.01, 0.02, 0.05, 0.05, 0.29], index=df.index)
+    penalty_bands = {
+        ("Karnataka", "solar"): [
+            (10, 20, 0.1),  # Band 1
+            (20, 30, 0.5),  # Band 2
+            (30, None, 0.75),  # Open-ended Band
+        ]
+    }
 
-    # Run penalty calculation
+    if (region, asset_type) not in penalty_bands:
+        pytest.fail(f"No penalty bands found for region '{region}' and asset type '{asset_type}'")
+
     penalty_df, total_penalty = calculate_penalty(df, str(region), str(asset_type), capacity_kw)
-
-    # Debugging outputs
-    print("Calculated total penalty:", total_penalty)
-    print("Calculated penalties by block:", penalty_df)
+    
+    # Updated expected results based on correct calculations
+    expected_penalty_df = pd.Series([0.0, 0.0, 0.1, 0.0, 0.5], index=df.index)
+    expected_total_penalty = 0.6
 
     # Assertions
     np.testing.assert_almost_equal(total_penalty, expected_total_penalty, decimal=2)
-    pd.testing.assert_series_equal(penalty_df, expected_penalty_df, check_dtype=False)
+    pd.testing.assert_series_equal(
+        penalty_df,
+        expected_penalty_df,
+        check_dtype=False,
+        check_exact=False,
+    )

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -6,40 +6,53 @@ import pytest
 
 def test_calculate_penalty():
     """
-    Test the calculate_penalty function with mock data and fixed capacity.
+    Test the calculate_penalty function with mock data, regions, asset types, and dynamic capacities.
     """
 
-    # Create a mock DataFrame
+    # Mock input DataFrame
     df = pd.DataFrame(
         {
             "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
-            "forecast_power_kw": [0.1, 0.2, 0.3, 0.4, 0.5],
-            "generation_power_kw": [0.2, 0.3, 0.5, 0.5, 1],
+            "forecast_power_kw": [1, 2, 3, 4, 5],
+            "generation_power_kw": [2, 3, 4, 5, 10],
         }
     )
 
-    # Assume capacity and mock region + asset type mapping
-    capacity_kw = 2
+    # Mock region, asset type, and capacity
     region = "Karnataka"
     asset_type = "solar"
+    capacity_kw = 200  # Capacity specific to the mock site
 
-    # Set penalty bands for the region and asset type
+    # Penalty bands configuration
     penalty_bands = {
         ("Karnataka", "solar"): [
-            (10, 20, 0.1),  # Band 1 (lowest block, highest block, penalty )
+            (10, 20, 0.1),  # Band 1
             (20, 30, 0.5),  # Band 2
             (30, None, 0.75),  # Open-ended Band
         ]
     }
 
-    # Calculate penalty
-    penalty_df, total_penalty = calculate_penalty(df, str(region), str(asset_type), capacity_kw)
+    # Check if penalty bands exist for the provided region and asset type
+    if (region, asset_type) not in penalty_bands:
+        pytest.fail(f"No penalty bands found for region '{region}' and asset type '{asset_type}'")
 
-    # Expected results for validation
-    expected_total_penalty = 0.42  # Adjust based on correct calculations
+    # Call the calculate_penalty function
+    penalty_df, total_penalty = calculate_penalty(df, region, asset_type, capacity_kw)
+
+    # Define expected results
+    expected_total_penalty = 0.42  # Update based on correct manual calculations
     expected_penalty_df = pd.Series([0.01, 0.02, 0.05, 0.05, 0.29], index=df.index)
 
     # Assertions
     np.testing.assert_almost_equal(total_penalty, expected_total_penalty, decimal=2)
-    pd.testing.assert_series_equal(penalty_df, expected_penalty_df, check_dtype=False)
+    pd.testing.assert_series_equal(
+        penalty_df,
+        expected_penalty_df,
+        check_dtype=False,
+        check_exact=False,
+    )
+
+    # Print outputs for debugging
+    print("Penalty DataFrame:\n", penalty_df)
+    print("Total Penalty:", total_penalty)
 

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -5,31 +5,40 @@ import pytest
 
 
 def test_calculate_penalty():
+    """
+    Test the calculate_penalty function with mock data, ensuring it matches the implementation.
+    """
+    # Mock input DataFrame
     df = pd.DataFrame(
         {
             "datetime": pd.date_range("2021-01-01", periods=5, freq="D"),
             "forecast_power_kw": [0.1, 0.2, 0.3, 0.4, 0.5],
-            "generation_power_kw": [0.2, 0.3, 0.5, 0.5, 1],
+            "generation_power_kw": [0.2, 0.3, 0.5, 0.5, 1.0],
         }
     )
 
     region = "Karnataka"
     asset_type = "solar"
-    capacity_kw = 2
-
-    penalty_bands = {
-        ("Karnataka", "solar"): [
-            (10, 20, 0.25),
-            (20, 30, 0.5),
-            (30, None, 0.75),
-        ]
-    }
+    capacity_kw = 2.0
 
     penalty_df, total_penalty = calculate_penalty(df, str(region), str(asset_type), capacity_kw)
-    
-    expected_penalty_df = pd.Series([0.0, 0.0, 0.0, 0.0, 0.3], index=df.index)
+
+    # For Karnataka solar:
+    # - 10-20%: 0.25 penalty rate
+    # - 20-30%: 0.50 penalty rate
+    # - >30%: 0.75 penalty rate
+
+    # Calculate for each row:
+    # Row 1: (0.2 - 0.1)/2 * 100 = 5% -> No penalty
+    # Row 2: (0.3 - 0.2)/2 * 100 = 5% -> No penalty
+    # Row 3: (0.5 - 0.3)/2 * 100 = 10% -> 0.25 rate * abs(0.5-0.3) = 0.05
+    # Row 4: (0.5 - 0.4)/2 * 100 = 5% -> No penalty
+    # Row 5: (1.0 - 0.5)/2 * 100 = 25% -> 0.50 rate * abs(1.0-0.5) = 0.25
+
+    expected_penalty_df = pd.Series([0.0, 0.0, 0.05, 0.0, 0.25], index=df.index)
     expected_total_penalty = 0.3
 
+    # Assertions
     np.testing.assert_almost_equal(total_penalty, expected_total_penalty, decimal=2)
     pd.testing.assert_series_equal(
         penalty_df,

--- a/tests/test_pvsite_location.py
+++ b/tests/test_pvsite_location.py
@@ -26,14 +26,14 @@ def test_calculate_penalty():
     # Set penalty bands for the region and asset type
     penalty_bands = {
         ("Karnataka", "solar"): [
-            (10, 20, 0.1),  # Band 1
+            (10, 20, 0.1),  # Band 1 (lowest block, highest block, penalty )
             (20, 30, 0.5),  # Band 2
             (30, None, 0.75),  # Open-ended Band
         ]
     }
 
     # Calculate penalty
-    penalty_df, total_penalty = calculate_penalty(df, region, asset_type, capacity_kw, penalty_bands)
+    penalty_df, total_penalty = calculate_penalty(df, str(region), str(asset_type), capacity_kw)
 
     # Expected results for validation
     expected_total_penalty = 0.42  # Adjust based on correct calculations


### PR DESCRIPTION
# Pull Request

## Description

The following changes in the code makes sure that we are tracking site wise penalty calculations, as each site/state/generation type has different penalty bands

## How Has This Been Tested?
The code has been ran locally to see if it works

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/166da7d8-863f-4c3a-8a2b-ab0826c0277a" />
 

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
