### PR TITLE
Rename MAE plot line from "Daily Total MAE" to "Latest Forecast"

### DIFF
--- a/src/plots/forecast_horizon.py
+++ b/src/plots/forecast_horizon.py
@@ -24,7 +24,7 @@ def make_mae_by_forecast_horizon(
             x=df_mae["datetime_utc"],
             y=df_mae["MAE"],
             mode="lines",
-            name="Daily Total MAE",
+            name="Latest Forecast",
             line=dict(color="#FFD053"),
         )
     )


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves the issue of renaming "Daily Total MAE" to "Latest Forecast" in the MAE by Horizon plot as described in issue #193 .  The changes ensure consistent terminology and improve clarity in the plot labels.


Fixes #193 

## How Has This Been Tested?

Run it locally

- [x] Yes

The changes were tested to ensure functionality and consistency.  

### Steps to Reproduce:
You can reproduce the changes by opening the file located at `src\plots\forecast_horizon.py` and inspecting line number 27. When you create the `forecast_horizon` chart, you will see the updated label, "Latest Forecast," displayed correctly.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
