### PR TITLE
Added CI Tests for External PRs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,15 +2,16 @@ name: Python package tests
 
 on:
   push:
+  pull_request:
+    types: [opened, synchronize, reopened]  
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]  
   schedule:
     - cron: "0 12 * * 1"
 jobs:
   call-run-python-tests:
     uses: openclimatefix/.github/.github/workflows/python-test.yml@v1.8.4
     with:
-      # default python versions to use
       python-version: "['3.11']"
-      # pytest-cov looks at this folder
       pytest_cov_dir: "src"
-      #      brew_install: "proj geos librttopo"
       os_list: '["ubuntu-latest"]'


### PR DESCRIPTION
# Pull Request

## Description

This update modifies the GitHub Actions workflow to trigger `pytest.yml` CI tests on external pull requests (PRs). The workflow is now set to run tests on PR creation, updates, reopening, and when marked as "ready for review".

Fix #251 
## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
