### PR TITLE
feat: Add country and asset type inputs to sites toolbox page

### DIFF
--- a/src/site_toolbox/get_details.py
+++ b/src/site_toolbox/get_details.py
@@ -37,6 +37,7 @@ def get_site_details(session, site_uuid: str):
         "latitude": str(site.latitude),
         "longitude": str(site.longitude),
         "country": str(site.country),
+        "asset_type": site.asset_type.name if hasattr(site.asset_type, 'name') else str(site.asset_type),
         "region": str(site.region),
         "DNO": str(site.dno),
         "GSP": str(site.gsp),

--- a/src/site_toolbox/get_details.py
+++ b/src/site_toolbox/get_details.py
@@ -8,7 +8,7 @@ from pvsite_datamodel.read import (
     get_site_by_uuid,
     get_site_group_by_name
 )
-
+from pvsite_datamodel.sqlmodels import SiteAssetType
 
 # get details for one user
 def get_user_details(session, email: str):
@@ -27,6 +27,14 @@ def get_user_details(session, email: str):
 def get_site_details(session, site_uuid: str):
     """Get the site details for one site"""
     site = get_site_by_uuid(session=session, site_uuid=site_uuid)
+    
+    if isinstance(site.asset_type, SiteAssetType):
+        # Use the name attribute to get a human-readable string (like 'pv')
+        asset_type_value = site.asset_type.name.lower()  # 'pv' or 'wind'
+    else:
+        # If asset_type is not an Enum, just use its string representation
+        asset_type_value = str(site.asset_type)
+        
     site_details = {
         "site_uuid": str(site.site_uuid),
         "client_site_id": str(site.client_site_id),
@@ -37,7 +45,7 @@ def get_site_details(session, site_uuid: str):
         "latitude": str(site.latitude),
         "longitude": str(site.longitude),
         "country": str(site.country),
-        "asset_type": site.asset_type.name if hasattr(site.asset_type, 'name') else str(site.asset_type),
+        "asset_type": asset_type_value,
         "region": str(site.region),
         "DNO": str(site.dno),
         "GSP": str(site.gsp),

--- a/src/site_toolbox/get_details.py
+++ b/src/site_toolbox/get_details.py
@@ -29,10 +29,8 @@ def get_site_details(session, site_uuid: str):
     site = get_site_by_uuid(session=session, site_uuid=site_uuid)
     
     if isinstance(site.asset_type, SiteAssetType):
-        # Use the name attribute to get a human-readable string (like 'pv')
         asset_type_value = site.asset_type.name.lower()  # 'pv' or 'wind'
     else:
-        # If asset_type is not an Enum, just use its string representation
         asset_type_value = str(site.asset_type)
         
     site_details = {

--- a/src/sites_toolbox.py
+++ b/src/sites_toolbox.py
@@ -8,6 +8,7 @@ from pvsite_datamodel.read import (
     get_all_sites,
 )
 from pvsite_datamodel.read.model import get_models
+from pvsite_datamodel.sqlmodels import SiteAssetType
 
 from get_data import get_all_users, get_all_site_groups
 from pvsite_datamodel.write.user_and_site import (
@@ -221,6 +222,13 @@ def sites_toolbox_page():
             latitude = st.text_input("latitude *")
             longitude = st.text_input("longitude *")
             region = st.text_input("region")
+            country = st.text_input("Country", value="UK", placeholder="Default is 'UK'")
+            asset_type = st.selectbox(
+                "Asset Type",
+                options=[e.name for e in SiteAssetType],
+                format_func=lambda x: x.replace("_", " ").title(),
+                index=list(SiteAssetType).index(SiteAssetType.pv),  # Default to 'pv'
+            )
 
             st.markdown(
                 f'<h1 style="color:#FFD053;font-size:22px;">{"PV Information"}</h1>',
@@ -239,6 +247,8 @@ def sites_toolbox_page():
                     latitude,
                     longitude,
                     capacity_kw,
+                    country,
+                    asset_type,
                 ]:
                     error = (
                         f"Please check that you've entered data for each field. "
@@ -259,6 +269,8 @@ def sites_toolbox_page():
                         inverter_capacity_kw=inverter_capacity_kw,
                         module_capacity_kw=module_capacity_kw,
                         capacity_kw=capacity_kw,
+                        country=country,
+                        asset_type=asset_type,
                     )
                     site_details = {
                         "site_uuid": str(site.site_uuid),
@@ -271,6 +283,8 @@ def sites_toolbox_page():
                         ],
                         "latitude": str(site.latitude),
                         "longitude": str(site.longitude),
+                        "country": str(site.country),
+                        "asset_type": str(site.asset_type),
                         "DNO": str(site.dno),
                         "GSP": str(site.gsp),
                         "tilt": str(site.tilt),

--- a/tests/test_sites_toolbox.py
+++ b/tests/test_sites_toolbox.py
@@ -8,6 +8,7 @@ from sites_toolbox import (
     update_site_group,
     add_all_sites_to_ocf_group,
 )
+from pvsite_datamodel.sqlmodels import SiteAssetType
 
 from pvsite_datamodel.write.user_and_site import make_fake_site, create_site_group, create_user
 

--- a/tests/test_sites_toolbox.py
+++ b/tests/test_sites_toolbox.py
@@ -42,6 +42,12 @@ def test_get_site_details(db_session):
     site = make_fake_site(db_session=db_session, ml_id=1)
 
     site_details = get_site_details(session=db_session, site_uuid=str(site.site_uuid))
+    
+    if isinstance(site.asset_type, SiteAssetType):
+        asset_type_value = str(site.asset_type.name.lower())  # 'pv' or 'wind'
+    else:
+        asset_type_value = str(site.asset_type)
+        
 
     assert site_details == {
         "site_uuid": str(site.site_uuid),
@@ -51,6 +57,7 @@ def test_get_site_details(db_session):
             site_group.site_group_name for site_group in site.site_groups
         ],
         'country': 'uk',
+        'asset_type': asset_type_value,
         "latitude": str(site.latitude),
         "longitude": str(site.longitude),
         "DNO": str(site.dno),


### PR DESCRIPTION
# Pull Request

## Description

This PR adds an option to include `county` and `asset type` when adding sites in the tool. The new fields are incorporated into the display object and the tool's functionality is updated accordingly.

Fixes #224 

## How Has This Been Tested?

The following tests were performed to verify the changes:

- Added unit tests to ensure the new fields are correctly added to the display object.
- Manually tested the functionality by adding sites with `county` and `asset type` fields.
- Conducted a quick sanity check to validate the data processing for the new fields.


https://github.com/user-attachments/assets/01dd3a58-0d18-49e5-8607-7183b1ef6314



## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
