### PR TITLE
addition of new sites will be displayed on dashboard

### DIFF
--- a/src/plots/users.py
+++ b/src/plots/users.py
@@ -1,5 +1,8 @@
 import pandas as pd
-from plotly import graph_objects as go
+import plotly.graph_objects as go
+from pvsite_datamodel.read.user import get_user_by_email
+from pvsite_datamodel.read.site import get_sites_from_user
+import streamlit as st
 
 from datetime import datetime
 
@@ -75,3 +78,41 @@ def make_api_frequency_requests_plot(
     )
     fig.update_yaxes(visible=False)
     return fig
+
+def make_sites_over_time_plot(session, email):
+    """
+    Create a bar chart showing the cumulative number of sites forecasted for a user over time.
+    
+    Args:
+        session: SQLAlchemy session object.
+        email (str): Email of the user.
+    
+    Returns:
+        plotly.graph_objects.Figure: The bar chart figure.
+    """
+    # Get user and their sites
+    user = get_user_by_email(session=session, email=email)
+    sites = get_sites_from_user(session=session, user=user)
+    
+    # Convert sites to a DataFrame
+    sites_df = pd.DataFrame([site.__dict__ for site in sites], columns=["created_utc"])
+    sites_df['created_utc'] = pd.to_datetime(sites_df['created_utc'])
+    #printout number of sites to doublecheck
+    
+    # Group by month and calculate cumulative counts
+    monthly_cumulative = sites_df.groupby(pd.Grouper(key='created_utc', freq='ME')).size().cumsum()
+
+    
+    # Create the line graph
+    fig = go.Figure(
+        data=go.Scatter(x=monthly_cumulative.index, y=monthly_cumulative, mode='lines+markers', name="Sites"),
+        layout=dict(
+            title=f'Increase in Number of Sites Over Time for {email}',
+            xaxis_title="Date",
+            yaxis_title="Cumulative Number of Sites",
+            showlegend=True
+        )
+    )
+
+    # Display the graph in Streamlit
+    st.plotly_chart(fig, theme="streamlit")

--- a/src/plots/users.py
+++ b/src/plots/users.py
@@ -81,14 +81,14 @@ def make_api_frequency_requests_plot(
 
 def make_sites_over_time_plot(session, email):
     """
-    Create a bar chart showing the cumulative number of sites forecasted for a user over time.
+    Create a line chart showing the cumulative number of sites forecasted for a user over time.
     
     Args:
         session: SQLAlchemy session object.
         email (str): Email of the user.
     
     Returns:
-        plotly.graph_objects.Figure: The bar chart figure.
+        plotly.graph_objects.Figure: The line chart figure.
     """
     # Get user and their sites
     user = get_user_by_email(session=session, email=email)
@@ -97,12 +97,10 @@ def make_sites_over_time_plot(session, email):
     # Convert sites to a DataFrame
     sites_df = pd.DataFrame([site.__dict__ for site in sites], columns=["created_utc"])
     sites_df['created_utc'] = pd.to_datetime(sites_df['created_utc'])
-    #printout number of sites to doublecheck
     
     # Group by month and calculate cumulative counts
     monthly_cumulative = sites_df.groupby(pd.Grouper(key='created_utc', freq='ME')).size().cumsum()
 
-    
     # Create the line graph
     fig = go.Figure(
         data=go.Scatter(x=monthly_cumulative.index, y=monthly_cumulative, mode='lines+markers', name="Sites"),
@@ -114,5 +112,4 @@ def make_sites_over_time_plot(session, email):
         )
     )
 
-    # Display the graph in Streamlit
-    st.plotly_chart(fig, theme="streamlit")
+    return fig  


### PR DESCRIPTION
# Pull Request
The following update to the code will display the progression of sites allocated per users over time.
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/74f3c390-7d9b-45c2-8014-045f1653298c" />

This Pr is in correspondence to the issue: https://github.com/openclimatefix/analysis-dashboard/issues/260



## How Has This Been Tested?
The code has been tested locally


_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
