### PR TITLE
Updated pvsite-datamodel to 1.0.52 or above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 altair==5.5.0
 requests==2.32.3
 nowcasting_datamodel==1.5.56
-pvsite-datamodel==1.0.50
+pvsite-datamodel>=1.0.52
 numpy==2.0.0
 pandas==2.2.3
 plotly==5.24.1


### PR DESCRIPTION
### Description
Updated `pvsite-datamodel` version in `requirements.txt` to `>=1.0.52` to align with dependency requirements.

### How Has This Been Tested?
- Verified that `pvsite-datamodel` installs correctly.
- The update does not break the requirements file.

**Note:** Due to system-specific issues, `pygrib` failed to install on my machine, but this should not affect functionality as it works on other systems.

### Checklist
- [x] My code follows OCF's coding style
- [x] I have performed a self-review of my own code
- [x] I have checked that `pvsite-datamodel` installs correctly
