### PR TITLE
Load a week of API users

### DIFF
--- a/src/users.py
+++ b/src/users.py
@@ -43,7 +43,7 @@ def user_page():
         "Start Date",
         min_value=datetime.today() - timedelta(days=365),
         max_value=datetime.today(),
-        value=datetime.today() - timedelta(days=31),
+        value=datetime.today() - timedelta(days=7),
     )
     end_time = st.sidebar.date_input(
         "End Date",


### PR DESCRIPTION
# Pull Request

## Description

This PR reduces the API use usage initial load from 31 days down to 7 days. 

Fixes #

The analysis dashboard has been repeatedly crashing recently on the API user page. This should reduce the amount of data originally loaded.

## How Has This Been Tested?

This has not been tested locally, but it is a very small change that is not to anything critical for the app. 

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
