### PR TITLE
Hide all Elexon forecasts by default on forecast page

### DIFF
--- a/src/plots/elexon_plots.py
+++ b/src/plots/elexon_plots.py
@@ -62,11 +62,8 @@ def add_elexon_plot(
             full_time_df = pd.DataFrame(full_time_range, columns=["start_time"])
             forecast = full_time_df.merge(forecast, on="start_time", how="left")
 
-            # Set visibility based on process type
-            if process_types[i] in ["Intraday Process", "Intraday Total"]:
-                visibility = 'legendonly'
-            else:
-                visibility = True
+            # Hide all Elexon forecast types by default
+            visibility = 'legendonly'
 
             fig.add_trace(
                 go.Scatter(


### PR DESCRIPTION
# Pull Request

## Description

This PR hides all Elexon forecasts ("Day Ahead", "Intraday Process", and "Intraday Total") by default on the forecast page.

Currently, only "Intraday" forecasts were hidden by default (`legendonly`), while "Day Ahead" remained visible. This PR ensures **all** Elexon forecast traces are hidden on initial load to reduce visual clutter, and can be toggled via the legend.

Fixes: [#313 ]

## How Has This Been Tested?

Ran `streamlit run` locally and verified all Elexon forecasts appear in the legend but are hidden by default.

Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
