### PR TITLE
only show cumulativ sites plot if sites selected

### DIFF
--- a/src/users.py
+++ b/src/users.py
@@ -143,9 +143,10 @@ def user_page():
     st.plotly_chart(fig, theme="streamlit")
 
     # Plot cumulative sites over time as a line graph
-    with connection.get_session() as session:
-        fig = make_sites_over_time_plot(session=session, email=email_selected)
-        st.plotly_chart(fig, theme="streamlit")
+    if national_or_sites == "Sites":
+        with connection.get_session() as session:
+            fig = make_sites_over_time_plot(session=session, email=email_selected)
+            st.plotly_chart(fig, theme="streamlit")
 
 
 @st.cache_data(ttl=60 * 5)  # 5 mins


### PR DESCRIPTION
# Pull Request

## Description

Only show plot of sites on API sites page, not the National

## How Has This Been Tested?

CI tests

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
