### PR TITLE
Standardize time frequency strings to '15min' and '30min'

### DIFF
--- a/src/plots/elexon_plots.py
+++ b/src/plots/elexon_plots.py
@@ -56,7 +56,7 @@ def add_elexon_plot(
             full_time_range = pd.date_range(
                 start=start_datetime_utc,
                 end=end_datetime_utc,
-                freq="30T",
+                freq="30min",
                 tz=forecast["start_time"].dt.tz,
             )
             full_time_df = pd.DataFrame(full_time_range, columns=["start_time"])
@@ -112,7 +112,7 @@ def fetch_forecast_data(
 
         # Resample if there's data
         if not solar_df.empty:
-            solar_df = solar_df.resample("30T")["quantity"].sum().reset_index()
+            solar_df = solar_df.resample("30min")["quantity"].sum().reset_index()
 
         return solar_df
     except Exception as e:

--- a/src/pvsite_forecast.py
+++ b/src/pvsite_forecast.py
@@ -201,7 +201,7 @@ def pvsite_forecast_page():
             day_ahead_timezone_delta_hours = None
 
         # an option to resample to the data
-        resample = st.sidebar.selectbox("Resample data", [None, "15T", "30T"], None)
+        resample = st.sidebar.selectbox("Resample data", [None, "15min", "30min"], None)
 
         st.write(
             "Forecast for",
@@ -393,7 +393,7 @@ def pvsite_forecast_page():
     now = datetime.now().isoformat()
 
     if resample is None:
-        st.caption("Please resample to '15T' to get MAE")
+        st.caption("Please resample to '15min' to get MAE")
     else:
         metrics = []
         for model in ml_models:
@@ -473,7 +473,7 @@ def pvsite_forecast_page():
 
     # Check if resampling is applied - if not, show a clear message
     if resample is None:
-        st.warning("Please select a resample option (e.g., '15T') in the sidebar to view error metrics. Without resampling, error metrics cannot be calculated properly.")
+        st.warning("Please select a resample option (e.g., '15min') in the sidebar to view error metrics. Without resampling, error metrics cannot be calculated properly.")
     else:
         # Create time series of error metrics for each model
         error_dfs = {}

--- a/tests/test_elexon_plot.py
+++ b/tests/test_elexon_plot.py
@@ -43,7 +43,7 @@ def test_fetch_forecast_data_api_failure():
 def test_add_elexon_plot_with_data(mock_fetch):
     # Mock fetch_forecast_data to return a non-empty DataFrame
     mock_fetch.return_value = pd.DataFrame({
-        "start_time": pd.date_range("2024-08-01", periods=3, freq="30T"),
+        "start_time": pd.date_range("2024-08-01", periods=3, freq="30min"),
         "quantity": [100, 200, 150]
     })
 


### PR DESCRIPTION
Replaced deprecated or inconsistent pandas frequency strings ('15T', '30T') with '15min' and '30min' across code and tests for clarity and future compatibility.


Fixes #334 




