### PR TITLE
Changed the requirements.txt to install CPU-only torch.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ elexonpy==1.0.15
 fiona==1.10.1
 herbie-data
 numcodecs==0.15.1
-torch==2.7.1
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.7.1+cpu
 matplotlib==3.10.3


### PR DESCRIPTION


# Pull Request

## Description

Changed the torch library line in the `requirements.txt` file to download CPU-only torch.

Fixes #332

## How Has This Been Tested?

I created a new virtual environment using `python -m venv myenv`, then ran the `pip install -r requirements.txt` command to install the dependencies and checked with the `pip list` command to see that only torch CPU was installed for torch.

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
